### PR TITLE
show_tag! + str::to_string + tag_arg!

### DIFF
--- a/src/audio_file.rs
+++ b/src/audio_file.rs
@@ -50,20 +50,19 @@ impl fmt::Display for FileError {
 impl fmt::Display for AudioTags {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         macro_rules! show_tag {
-			($name: expr, $field:tt, $( $ref:tt )*) => {{
-				if let Some($( $ref )* tag) = self.$field {
-                    writeln!(f, "{}:\t{}", $name, tag)?
-				}
-			}};
-			($name:expr, $field:tt) => { show_tag!($name, $field,) };
-		}
-        show_tag!("title", title, ref);
-        show_tag!("artist", artist, ref);
-        show_tag!("album", album, ref);
-        show_tag!("comment", comment, ref);
-        show_tag!("genre", genre, ref);
-        show_tag!("year", year);
-        show_tag!("track", track);
+            ($field:tt) => {{
+                if let Some(ref tag) = self.$field {
+                    writeln!(f, "{}:\t{}", stringify!($field), tag)?
+                }
+            }};
+        }
+        show_tag!(title);
+        show_tag!(artist);
+        show_tag!(album);
+        show_tag!(comment);
+        show_tag!(genre);
+        show_tag!(year);
+        show_tag!(track);
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,15 +115,11 @@ fn run_editor(args: &ArgMatches) {
 /// Edit the tags according to what was provided in `args`
 fn run_quick_edit(args: &ArgMatches) {
     let tags: AudioTags = AudioTags {
-        title: args.value_of("title").map(std::string::ToString::to_string),
-        artist: args
-            .value_of("artist")
-            .map(std::string::ToString::to_string),
-        album: args.value_of("album").map(std::string::ToString::to_string),
-        comment: args
-            .value_of("comment")
-            .map(std::string::ToString::to_string),
-        genre: args.value_of("genre").map(std::string::ToString::to_string),
+        title: args.value_of("title").map(str::to_string),
+        artist: args.value_of("artist").map(str::to_string),
+        album: args.value_of("album").map(str::to_string),
+        comment: args.value_of("comment").map(str::to_string),
+        genre: args.value_of("genre").map(str::to_string),
         year: args
             .value_of("year")
             .map(|v| v.parse().expect("Year should be a integer")),
@@ -146,6 +142,15 @@ fn run_quick_edit(args: &ArgMatches) {
 }
 
 fn main() {
+    macro_rules! tag_arg {
+        ($name:expr, $short:expr) => {
+            Arg::with_name($name)
+                .short($short)
+                .long($name)
+                .help(concat!("Set ", $name, " tag"))
+                .takes_value(true)
+        }
+    }
     let app = ClapApp::new(crate_name!())
         .version(crate_version!())
         .about("Edit audio tags")
@@ -170,48 +175,12 @@ fn main() {
             SubCommand::with_name("quickedit")
                 .about("Update tag on the fly")
                 .arg(Arg::with_name("FILE").required(true).multiple(true))
-                .arg(
-                    Arg::with_name("title")
-                        .short("t")
-                        .long("title")
-                        .help("Set title tag")
-                        .takes_value(true),
-                )
-                .arg(
-                    Arg::with_name("album")
-                        .short("l")
-                        .long("album")
-                        .help("Set album tag")
-                        .takes_value(true),
-                )
-                .arg(
-                    Arg::with_name("artist")
-                        .short("r")
-                        .long("artist")
-                        .help("Set artist tag")
-                        .takes_value(true),
-                )
-                .arg(
-                    Arg::with_name("genre")
-                        .short("g")
-                        .long("genre")
-                        .help("Set genre tag")
-                        .takes_value(true),
-                )
-                .arg(
-                    Arg::with_name("track")
-                        .short("n")
-                        .long("track")
-                        .help("Set track tag")
-                        .takes_value(true),
-                )
-                .arg(
-                    Arg::with_name("year")
-                        .short("y")
-                        .long("year")
-                        .help("Set year tag")
-                        .takes_value(true),
-                ),
+                .arg(tag_arg!("title", "t"))
+                .arg(tag_arg!("album", "l"))
+                .arg(tag_arg!("artist", "r"))
+                .arg(tag_arg!("genre", "g"))
+                .arg(tag_arg!("track", "n"))
+                .arg(tag_arg!("year", "y"))
         )
         .get_matches();
     match app.subcommand() {


### PR DESCRIPTION
show_tag! macro does not need extra parameters thanks to
- stringify!
- &usize implementing same fmt::Display as usize

str::to_string replaces the alternative not needed
std::string::ToString::to_string

tag_arg! macro to cut down repetitive clap args


Je savais pas comment faire proprement la sélection de seulement les deux commits, donc j'ai repris sur un nouveau fork.